### PR TITLE
Add the ability to pass an instance of ``Mode``

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Plugin::load('Wrench');
 The plugin is built around a **DispatcherFilter** that will intercept the current request to
 return a customized response to warn the user that the website / app is undergoing maintenance.
 
-To use the Maintenance mode, you need to add the **MaintenanceModeFilter** to the 
+To use the Maintenance mode, you need to add the **MaintenanceModeFilter** to the
 **DispatcherFactory** in your bootstrap file using the following statement:
 
 ```php
@@ -77,6 +77,16 @@ The array of parameters is required to be of the following form:
 ]
 ```
 
+If you need it, you can directly pass an instance of a ``Mode`` to the ``mode`` array key of the filter's config:
+
+```php
+DispatcherFactory::add('Wrench.MaintenanceMode', [
+    'mode' => new \Wrench\Mode\Redirect([
+        'url' => 'http://example.com/maintenance'
+    ])
+]);
+```
+
 #### Redirect Mode
 
 The Redirect Mode is the default one. It will perform a redirect to a specific URL.
@@ -87,7 +97,7 @@ page.
 - **code** : The HTTP status code of the redirect response. The code should be in the 3XX range, otherwise, it might
  get overwritten. Default to 307.
 - **headers** : Array of additional headers to pass along the redirect response. Default to empty.
-  
+
 You can customize all those parameters :
 
 ```php
@@ -134,7 +144,7 @@ DispatcherFactory::add('Wrench.MaintenanceMode', [
 
 - [ ] Add a direct output / View layer mode
 - [ ] Document how to build a custom mode
-- [ ] Implement, test and write about passing a Mode instance
+- [x] Implement, test and write about passing a Mode instance
 - [ ] Test and write about the ``when`` and ``for`` options
 
 ## License

--- a/src/Routing/Filter/MaintenanceModeFilter.php
+++ b/src/Routing/Filter/MaintenanceModeFilter.php
@@ -16,6 +16,7 @@ use Cake\Event\Event;
 use Cake\Network\Response;
 use Cake\Routing\DispatcherFilter;
 use Wrench\Mode\Exception\MissingModeException;
+use Wrench\Mode\Mode;
 
 /**
  * Dispatcher filter responsible of intercepting request to
@@ -55,15 +56,22 @@ class MaintenanceModeFilter extends DispatcherFilter
     {
         parent::__construct($config);
 
-        $className = $this->config('mode.className');
-        if (empty($className)) {
-            throw new MissingModeException(['mode' => '']);
+        $mode = $this->config('mode');
+        if (is_array($mode)) {
+            $className = $this->config('mode.className');
+            if (empty($className)) {
+                throw new MissingModeException(['mode' => '']);
+            }
+
+            $config = $this->config('mode.config');
+            $filterConfig = !empty($config) ? $config : [];
+            $this->mode($className, $filterConfig);
+            return;
         }
 
-        $config = $this->config('mode.config');
-        $filterConfig = !empty($config) ? $config : [];
-
-        $this->mode($className, $filterConfig);
+        if ($mode instanceof Mode) {
+            $this->mode($mode);
+        }
     }
 
     /**
@@ -89,10 +97,10 @@ class MaintenanceModeFilter extends DispatcherFilter
                 throw new MissingModeException(['mode' => $mode]);
             }
 
-            $this->_mode = new $mode($config);
+            $mode = new $mode($config);
         }
 
-        return $this->_mode;
+        return $this->_mode = $mode;
     }
 
     /**

--- a/tests/TestCase/Routing/Filter/MaintenanceModeFilterTest.php
+++ b/tests/TestCase/Routing/Filter/MaintenanceModeFilterTest.php
@@ -14,6 +14,7 @@ namespace Wrench\Test\TestCase\Routing\Filter;
 use Cake\Event\Event;
 use Cake\Network\Request;
 use Cake\TestSuite\TestCase;
+use Wrench\Mode\Redirect;
 use Wrench\Routing\Filter\MaintenanceModeFilter;
 
 /**
@@ -33,5 +34,29 @@ class MaintenanceModeFilterTest extends TestCase
         $this->assertEquals('Wrench\Mode\Redirect', $filter->config('mode.className'));
         $this->assertEquals([], $filter->config('mode.config'));
         $this->assertInstanceOf('Wrench\Mode\Redirect', $filter->mode());
+    }
+
+    /**
+     * Test loading the filter by passing a Mode instance in the `mode` key
+     * of the filter config
+     *
+     * @return void
+     */
+    public function testMaintenanceModeFilterModeInstance()
+    {
+        $filter = new MaintenanceModeFilter([
+            'mode' => new Redirect([
+                'url' => 'http://example.com/maintenance/'
+            ])
+        ]);
+
+        $this->assertInstanceOf('Wrench\Mode\Redirect', $filter->mode());
+
+        $expected = [
+            'code' => 307,
+            'url' => 'http://example.com/maintenance/',
+            'headers' => []
+        ];
+        $this->assertEquals($expected, $filter->mode()->config());
     }
 }


### PR DESCRIPTION
Add the ability to pass an instance of `Mode` as the `mode` config key in the filter's configuration
