### PR TITLE
Add IP white listing

### DIFF
--- a/src/Middleware/MaintenanceMiddleware.php
+++ b/src/Middleware/MaintenanceMiddleware.php
@@ -163,6 +163,7 @@ class MaintenanceMiddleware
             return $request->clientIp();
         }
 
+        // @codeCoverageIgnoreStart
         if ($request instanceof ServerRequestInterface) {
             $ip = '';
             $serverParams = $request->getServerParams();
@@ -176,6 +177,7 @@ class MaintenanceMiddleware
 
             return $ip;
         }
+        // @codeCoverageIgnoreEnd
 
         return '';
     }

--- a/src/Middleware/MaintenanceMiddleware.php
+++ b/src/Middleware/MaintenanceMiddleware.php
@@ -24,13 +24,6 @@ use Wrench\Mode\Mode;
 class MaintenanceMiddleware
 {
     use InstanceConfigTrait;
-
-    /**
-     * IP whitelist for bypassing maintenance mode.
-     *
-     * @var mixed
-     */
-    public $whitelist;
     
     /**
      * Configuration of the mode for this instance of the middleware
@@ -51,7 +44,8 @@ class MaintenanceMiddleware
         'mode' => [
             'className' => 'Wrench\Mode\Redirect',
             'config' => []
-        ]
+        ],
+        'whitelist' => []
     ];
 
     /**
@@ -62,7 +56,6 @@ class MaintenanceMiddleware
     public function __construct($config = [])
     {
         $this->config($config);
-        $this->whitelist = Configure::read('Wrench.whitelist');
         $mode = $this->_config['mode'];
 
         if (is_array($mode)) {
@@ -147,9 +140,8 @@ class MaintenanceMiddleware
             return false;
         }
 
-        foreach ($this->whitelist as $bypassIp) {
+        foreach ($this->_config['whitelist'] as $bypassIp) {
             if ($ip === $bypassIp) {
-                Configure::write('Wrench.bypass', $ip);
 
                 return true;
             }

--- a/tests/TestCase/Mode/CallbackTest.php
+++ b/tests/TestCase/Mode/CallbackTest.php
@@ -37,6 +37,7 @@ class CallbackTest extends TestCase
     public function testMaintenanceModeCallback()
     {
         Configure::write('Wrench.enable', true);
+        Configure::write('Wrench.whitelist', ['127.0.0.1']);
         $request = ServerRequestFactory::fromGlobals([
             'HTTP_HOST' => 'localhost',
             'REQUEST_URI' => '/'
@@ -79,6 +80,7 @@ class CallbackTest extends TestCase
     public function testMaintenanceModeCallbackException()
     {
         Configure::write('Wrench.enable', true);
+        Configure::write('Wrench.whitelist', ['127.0.0.1']);
         $request = ServerRequestFactory::fromGlobals([
             'HTTP_HOST' => 'localhost',
             'REQUEST_URI' => '/'

--- a/tests/TestCase/Mode/CallbackTest.php
+++ b/tests/TestCase/Mode/CallbackTest.php
@@ -39,7 +39,8 @@ class CallbackTest extends TestCase
         Configure::write('Wrench.enable', true);
         $request = ServerRequestFactory::fromGlobals([
             'HTTP_HOST' => 'localhost',
-            'REQUEST_URI' => '/'
+            'REQUEST_URI' => '/',
+            'REMOTE_ADDR' => '127.0.0.1'
         ]);
         $response = new Response();
         $next = function ($req, $res) {
@@ -81,7 +82,8 @@ class CallbackTest extends TestCase
         Configure::write('Wrench.enable', true);
         $request = ServerRequestFactory::fromGlobals([
             'HTTP_HOST' => 'localhost',
-            'REQUEST_URI' => '/'
+            'REQUEST_URI' => '/',
+            'REMOTE_ADDR' => '127.0.0.1'
         ]);
         $response = new Response();
         $next = function ($req, $res) {

--- a/tests/TestCase/Mode/OutputTest.php
+++ b/tests/TestCase/Mode/OutputTest.php
@@ -38,7 +38,8 @@ class OutputTest extends TestCase
         Configure::write('Wrench.enable', true);
         $request = ServerRequestFactory::fromGlobals([
             'HTTP_HOST' => 'localhost',
-            'REQUEST_URI' => '/'
+            'REQUEST_URI' => '/',
+            'REMOTE_ADDR' => '127.0.0.1'
         ]);
         $response = new Response();
         $next = function ($req, $res) {
@@ -66,7 +67,8 @@ class OutputTest extends TestCase
         Configure::write('Wrench.enable', true);
         $request = ServerRequestFactory::fromGlobals([
             'HTTP_HOST' => 'localhost',
-            'REQUEST_URI' => '/'
+            'REQUEST_URI' => '/',
+            'REMOTE_ADDR' => '127.0.0.1'
         ]);
         $response = new Response();
         $next = function ($req, $res) {
@@ -103,7 +105,8 @@ class OutputTest extends TestCase
         Configure::write('Wrench.enable', true);
         $request = ServerRequestFactory::fromGlobals([
             'HTTP_HOST' => 'localhost',
-            'REQUEST_URI' => '/'
+            'REQUEST_URI' => '/',
+            'REMOTE_ADDR' => '127.0.0.1'
         ]);
         $response = new Response();
         $next = function ($req, $res) {

--- a/tests/TestCase/Mode/OutputTest.php
+++ b/tests/TestCase/Mode/OutputTest.php
@@ -36,6 +36,7 @@ class OutputTest extends TestCase
     public function testOutputModeNoParams()
     {
         Configure::write('Wrench.enable', true);
+        Configure::write('Wrench.whitelist', ['127.0.0.1']);
         $request = ServerRequestFactory::fromGlobals([
             'HTTP_HOST' => 'localhost',
             'REQUEST_URI' => '/'
@@ -64,6 +65,7 @@ class OutputTest extends TestCase
     public function testMaintenanceModeFilterOutputHeaders()
     {
         Configure::write('Wrench.enable', true);
+        Configure::write('Wrench.whitelist', ['127.0.0.1']);
         $request = ServerRequestFactory::fromGlobals([
             'HTTP_HOST' => 'localhost',
             'REQUEST_URI' => '/'
@@ -101,6 +103,7 @@ class OutputTest extends TestCase
     public function testOutputModeCustomParams()
     {
         Configure::write('Wrench.enable', true);
+        Configure::write('Wrench.whitelist', ['127.0.0.1']);
         $request = ServerRequestFactory::fromGlobals([
             'HTTP_HOST' => 'localhost',
             'REQUEST_URI' => '/'

--- a/tests/TestCase/Mode/OutputTest.php
+++ b/tests/TestCase/Mode/OutputTest.php
@@ -36,7 +36,6 @@ class OutputTest extends TestCase
     public function testOutputModeNoParams()
     {
         Configure::write('Wrench.enable', true);
-        Configure::write('Wrench.whitelist', ['127.0.0.1']);
         $request = ServerRequestFactory::fromGlobals([
             'HTTP_HOST' => 'localhost',
             'REQUEST_URI' => '/'
@@ -65,7 +64,6 @@ class OutputTest extends TestCase
     public function testMaintenanceModeFilterOutputHeaders()
     {
         Configure::write('Wrench.enable', true);
-        Configure::write('Wrench.whitelist', ['127.0.0.1']);
         $request = ServerRequestFactory::fromGlobals([
             'HTTP_HOST' => 'localhost',
             'REQUEST_URI' => '/'
@@ -103,7 +101,6 @@ class OutputTest extends TestCase
     public function testOutputModeCustomParams()
     {
         Configure::write('Wrench.enable', true);
-        Configure::write('Wrench.whitelist', ['127.0.0.1']);
         $request = ServerRequestFactory::fromGlobals([
             'HTTP_HOST' => 'localhost',
             'REQUEST_URI' => '/'
@@ -121,5 +118,36 @@ class OutputTest extends TestCase
             ]
         ]);
         $middleware($request, $response, $next);
+    }
+
+    /**
+     * Test the Output filter mode without params when using the "whitelist" option. Meaning the maintenance mode should
+     * not be shown if the client IP is whitelisted.
+     *
+     * @return void
+     */
+    public function testOutputModeWhitelist()
+    {
+        Configure::write('Wrench.enable', true);
+        $request = ServerRequestFactory::fromGlobals([
+            'HTTP_HOST' => 'localhost',
+            'REQUEST_URI' => '/',
+            'REMOTE_ADDR' => '127.0.0.1'
+        ]);
+        $response = new Response();
+        $next = function ($req, $res) {
+            return $res;
+        };
+        $middleware = new MaintenanceMiddleware([
+            'whitelist' => ['127.0.0.1'],
+            'mode' => [
+                'className' => 'Wrench\Mode\Output'
+            ]
+        ]);
+        $res = $middleware($request, $response, $next);
+
+        $this->assertEquals(200, $res->getStatusCode());
+
+        $this->assertEquals($res->getBody(), '');
     }
 }

--- a/tests/TestCase/Mode/RedirectTest.php
+++ b/tests/TestCase/Mode/RedirectTest.php
@@ -38,7 +38,8 @@ class RedirectTest extends TestCase
         Configure::write('Wrench.enable', true);
         $request = ServerRequestFactory::fromGlobals([
             'HTTP_HOST' => 'localhost',
-            'REQUEST_URI' => '/'
+            'REQUEST_URI' => '/',
+            'REMOTE_ADDR' => '127.0.0.1'
         ]);
         $response = new Response();
         $next = function ($req, $res) {
@@ -60,7 +61,8 @@ class RedirectTest extends TestCase
         Configure::write('Wrench.enable', true);
         $request = ServerRequestFactory::fromGlobals([
             'HTTP_HOST' => 'localhost',
-            'REQUEST_URI' => '/'
+            'REQUEST_URI' => '/',
+            'REMOTE_ADDR' => '127.0.0.1'
         ]);
         $response = new Response();
         $next = function ($req, $res) {
@@ -91,7 +93,8 @@ class RedirectTest extends TestCase
         Configure::write('Wrench.enable', true);
         $request = ServerRequestFactory::fromGlobals([
             'HTTP_HOST' => 'localhost',
-            'REQUEST_URI' => '/'
+            'REQUEST_URI' => '/',
+            'REMOTE_ADDR' => '127.0.0.1'
         ]);
         $response = new Response();
         $next = function ($req, $res) {

--- a/tests/TestCase/Mode/RedirectTest.php
+++ b/tests/TestCase/Mode/RedirectTest.php
@@ -36,7 +36,6 @@ class RedirectTest extends TestCase
     public function testRedirectModeNoParams()
     {
         Configure::write('Wrench.enable', true);
-        Configure::write('Wrench.whitelist', ['127.0.0.1']);
         $request = ServerRequestFactory::fromGlobals([
             'HTTP_HOST' => 'localhost',
             'REQUEST_URI' => '/'
@@ -59,7 +58,6 @@ class RedirectTest extends TestCase
     public function testRedirectModeCustomParams()
     {
         Configure::write('Wrench.enable', true);
-        Configure::write('Wrench.whitelist', ['127.0.0.1']);
         $request = ServerRequestFactory::fromGlobals([
             'HTTP_HOST' => 'localhost',
             'REQUEST_URI' => '/'
@@ -91,7 +89,6 @@ class RedirectTest extends TestCase
     public function testMaintenanceModeFilterRedirectHeaders()
     {
         Configure::write('Wrench.enable', true);
-        Configure::write('Wrench.whitelist', ['127.0.0.1']);
         $request = ServerRequestFactory::fromGlobals([
             'HTTP_HOST' => 'localhost',
             'REQUEST_URI' => '/'
@@ -117,5 +114,31 @@ class RedirectTest extends TestCase
         $this->assertEquals('http://www.example.com/maintenance.html', $middlewareResponse->getHeaderLine('location'));
         $this->assertEquals('someValue', $middlewareResponse->getHeaderLine('someHeader'));
         $this->assertEquals('additionalValue', $middlewareResponse->getHeaderLine('additionalHeader'));
+    }
+
+    /**
+     * Test the Redirect filter mode without params when using the "whitelist" option. Meaning the maintenance mode
+     * should not be shown if the client IP is whitelisted.
+     *
+     * @return void
+     */
+    public function testRedirectModeWhitelist()
+    {
+        Configure::write('Wrench.enable', true);
+        $request = ServerRequestFactory::fromGlobals([
+            'HTTP_HOST' => 'localhost',
+            'REQUEST_URI' => '/',
+            'REMOTE_ADDR' => '127.0.0.1'
+        ]);
+        $response = new Response();
+        $next = function ($req, $res) {
+            return $res;
+        };
+        $middleware = new MaintenanceMiddleware([
+            'whitelist' => ['127.0.0.1'],
+        ]);
+        $middlewareResponse = $middleware($request, $response, $next);
+
+        $this->assertEquals(200, $middlewareResponse->getStatusCode());
     }
 }

--- a/tests/TestCase/Mode/RedirectTest.php
+++ b/tests/TestCase/Mode/RedirectTest.php
@@ -36,6 +36,7 @@ class RedirectTest extends TestCase
     public function testRedirectModeNoParams()
     {
         Configure::write('Wrench.enable', true);
+        Configure::write('Wrench.whitelist', ['127.0.0.1']);
         $request = ServerRequestFactory::fromGlobals([
             'HTTP_HOST' => 'localhost',
             'REQUEST_URI' => '/'
@@ -58,6 +59,7 @@ class RedirectTest extends TestCase
     public function testRedirectModeCustomParams()
     {
         Configure::write('Wrench.enable', true);
+        Configure::write('Wrench.whitelist', ['127.0.0.1']);
         $request = ServerRequestFactory::fromGlobals([
             'HTTP_HOST' => 'localhost',
             'REQUEST_URI' => '/'
@@ -89,6 +91,7 @@ class RedirectTest extends TestCase
     public function testMaintenanceModeFilterRedirectHeaders()
     {
         Configure::write('Wrench.enable', true);
+        Configure::write('Wrench.whitelist', ['127.0.0.1']);
         $request = ServerRequestFactory::fromGlobals([
             'HTTP_HOST' => 'localhost',
             'REQUEST_URI' => '/'

--- a/tests/TestCase/Mode/ViewTest.php
+++ b/tests/TestCase/Mode/ViewTest.php
@@ -46,6 +46,7 @@ class ViewTest extends TestCase
     public function testViewModeNoParams()
     {
         Configure::write('Wrench.enable', true);
+        Configure::write('Wrench.whitelist', ['127.0.0.1']);
         $request = ServerRequestFactory::fromGlobals([
             'HTTP_HOST' => 'localhost',
             'REQUEST_URI' => '/'
@@ -77,6 +78,7 @@ class ViewTest extends TestCase
     public function testViewModeCustomParams()
     {
         Configure::write('Wrench.enable', true);
+        Configure::write('Wrench.whitelist', ['127.0.0.1']);
 
         $request = ServerRequestFactory::fromGlobals([
             'HTTP_HOST' => 'localhost',
@@ -115,7 +117,8 @@ class ViewTest extends TestCase
     public function testViewModeCustomParamsPlugin()
     {
         Configure::write('Wrench.enable', true);
-
+        Configure::write('Wrench.whitelist', ['127.0.0.1']);
+        
         $request = ServerRequestFactory::fromGlobals([
             'HTTP_HOST' => 'localhost',
             'REQUEST_URI' => '/'

--- a/tests/TestCase/Mode/ViewTest.php
+++ b/tests/TestCase/Mode/ViewTest.php
@@ -48,7 +48,8 @@ class ViewTest extends TestCase
         Configure::write('Wrench.enable', true);
         $request = ServerRequestFactory::fromGlobals([
             'HTTP_HOST' => 'localhost',
-            'REQUEST_URI' => '/'
+            'REQUEST_URI' => '/',
+            'REMOTE_ADDR' => '127.0.0.1'
         ]);
         $response = new Response();
         $next = function ($req, $res) {
@@ -80,7 +81,8 @@ class ViewTest extends TestCase
 
         $request = ServerRequestFactory::fromGlobals([
             'HTTP_HOST' => 'localhost',
-            'REQUEST_URI' => '/'
+            'REQUEST_URI' => '/',
+            'REMOTE_ADDR' => '127.0.0.1'
         ]);
         $response = new Response();
         $next = function ($req, $res) {
@@ -118,7 +120,8 @@ class ViewTest extends TestCase
 
         $request = ServerRequestFactory::fromGlobals([
             'HTTP_HOST' => 'localhost',
-            'REQUEST_URI' => '/'
+            'REQUEST_URI' => '/',
+            'REMOTE_ADDR' => '127.0.0.1'
         ]);
         $response = new Response();
         $next = function ($req, $res) {


### PR DESCRIPTION
Add IP white listing.  Set the IP's via configure `Configure::write('Wrench.whitelist', ['someip','anotherip'])` or in a separate config file.  If IP is bypassed a bypass config is set with the current IP that you can use to set a flash message from AppController that maintenance mode is active.